### PR TITLE
Update mycp2.c

### DIFF
--- a/ch04/mycp2.c
+++ b/ch04/mycp2.c
@@ -65,6 +65,11 @@ int main(int argc, char* argv[]) {
 	while (1) {
 		cur_off = lseek(inputFd, cur_off, SEEK_DATA);
         data_off = cur_off;
+        // 後面無資料，只剩下洞的情況
+        if (data_off == -1 && errno == ENXIO){
+            ftruncate(outputFd, fileSize);
+            break;
+        }
 		cur_off = lseek(inputFd, cur_off, SEEK_HOLE);
         hole_off = cur_off;
         //第一種情況，資料在前面，洞在後面，不用特別處理


### PR DESCRIPTION
老師您好，ch04/mycp2.c程式無法複製『結尾為洞的檔案』。
根據lseek的manual page，當lseek() 失敗，且seek_data在檔案最後的洞裡面。lseek()回傳-1，並設定errno為ENXIO。
原程式碼在空洞結尾的狀況：

```c
 66         cur_off = lseek(inputFd, cur_off, SEEK_DATA);
 67         data_off = cur_off; // cur_off已經為-1!
 66         cur_off = lseek(inputFd, cur_off, SEEK_DATA); //顯然無法正常運行 複製大小也不對
 ```
 
 因此我在67行後加上:
 ```c
         if (data_off == -1 && errno == ENXIO){
            ftruncate(outputFd, fileSize);
            break;
 ```
確保遇到結尾空洞的情況能將檔案大小設定為fileSize，保留結尾空洞並退出迴圈。